### PR TITLE
Add option to use the original image as mask

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -24,6 +24,10 @@ pub struct Args {
     #[arg(short, long, value_parser = hex, default_value = "#171718")]
     pub color: [u8; 3],
 
+    /// Whether to use the original image as background
+    #[arg(short, long)]
+    pub original: bool,
+
     /// The translation to apply to the background image.
     /// (x, y)
     #[arg(short, long, value_parser = coords::<i32>, default_value = "0,0")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,12 +19,6 @@ fn main() {
         Err(_) => return println!("[-] Invalid Image Input"),
     };
 
-    // Translate
-    bg = DynamicImage::from(imageproc::geometric_transformations::translate(
-        &bg.to_rgb8(),
-        (arg.translate.0, arg.translate.1),
-    ));
-
     // Create foreground mask
     let size = arg.size.unwrap_or((bg.width(), bg.height()));
     let mut colored = if arg.original {
@@ -46,6 +40,12 @@ fn main() {
         ));
         single_color_bg
     };
+
+    // Translate
+    bg = DynamicImage::from(imageproc::geometric_transformations::translate(
+        &bg.to_rgb8(),
+        (arg.translate.0, arg.translate.1),
+    ));
 
     // Blur
     if let Some(i) = arg.blur {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,9 @@ fn main() {
     // Create foreground mask
     let size = arg.size.unwrap_or((bg.width(), bg.height()));
     let mut colored = if arg.original {
+        if arg.size.is_some() {
+            println!("[-] Using --size contradicts --original, the size will be ignored");
+        }
         Pixmap::from_vec(
             bg.to_rgba8().into_vec(),
             IntSize::from_wh(bg.width(), bg.height()).expect("Size too big"),


### PR DESCRIPTION
This allows the user to create images where the Arch Logo is "imprinted" in a darkened/blurred/translated version.
As an example, going from [this](https://www.pexels.com/photo/view-of-mountain-2105416/) image and using
`arch_papers -o -b 5 -d 40 -t 0,100 --bg-scale 0.75 input.jpg output.jpg`
Yields the following result:
![output](https://github.com/Basicprogrammer10/ArchPapers/assets/78028564/1f421a9b-43ce-4160-95fb-595b10a78ba0)
